### PR TITLE
Only use Rails.application.assets.find_asset in development

### DIFF
--- a/app/helpers/fuel/posts_helper.rb
+++ b/app/helpers/fuel/posts_helper.rb
@@ -15,7 +15,13 @@ module Fuel
     end
 
     def embedded_svg filename, options={}
-      path = Rails.application.assets.find_asset(filename).pathname
+      path =
+        if Rails.env.development?
+          Rails.application.assets.find_asset(filename).pathname
+        else
+          name = Rails.application.assets_manifest.assets[filename]
+          File.join(Rails.public_path, 'assets', name)
+        end
       file = File.read(path)
       doc = Nokogiri::HTML::DocumentFragment.parse file
       svg = doc.at_css 'svg'


### PR DESCRIPTION
* Due to updates in sprockets need to use Rails.application.assets_manifest.assets in non-development environments